### PR TITLE
Fixed config.yml in setup.md

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -95,6 +95,9 @@ framework:
    ...
    translator: { fallbacks: ["%locale%"] }
    serializer: { enable_annotations: true }
+   templating:
+      engines: ['twig']
+
 ```
 
 #### Add some config


### PR DESCRIPTION
## Type
documentation

## Purpose
I was fallowing this guide and kept having this error
```
  [RuntimeException]                                                         
  An error occurred when executing the "'cache:clear --no-warmup'" command:  
  In ParameterBag.php line 102:                                              
                                                                             
    You have requested a non-existent parameter "templating.engines". 
```
So I just added two lines to config.yml

This will avoid other to get this message

## BC Break
No